### PR TITLE
chore(license): add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sergio Andres Silva Martinez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Contexto
Se agrega el archivo `LICENSE` con licencia **MIT**, alineado con el estándar definido en el Blueprint 2025 del proyecto.  
Esto asegura que el código pueda ser usado, modificado y compartido libremente, manteniendo los créditos de autoría.

## Cambios
- Creación del archivo `LICENSE` con MIT License (2025, Sergio Andres Silva Martínez).

## Checklist
- [x] Archivo LICENSE creado en la raíz.
- [x] Licencia definida como MIT según buenas prácticas de repositorios open-source.
- [x] Commit y PR siguen convención de Conventional Commits (`chore(license): add MIT License`).

## Notas
Este PR corresponde a la configuración inicial del repositorio y prepara la base legal para futuros cambios.